### PR TITLE
Version of utils builds but missing FORTRAN endf converter

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@ execute_process(COMMAND python3 "${CMAKE_CURRENT_LIST_DIR}/../python/pyne2_${PYN
 # setup source files
 set(PYNE2_SRCS
   ${PYNE2_VERSION_HEADER}
+  utils.cpp
   )
 
 # compile and link library

--- a/src/cpp/utils.cpp
+++ b/src/cpp/utils.cpp
@@ -1,0 +1,379 @@
+// General Library
+#ifndef PYNE_IS_AMALGAMATED
+extern "C" double endftod_(char *str, int len);
+#endif
+#include <iomanip>
+
+#ifdef _WIN32
+  #include <filesystem>
+#endif
+
+#include "base_version.h"
+
+#ifndef PYNE_IS_AMALGAMATED
+#include "utils.h"
+#endif
+
+
+void pyne::pyne_start() {
+  return;
+}
+
+
+
+// String Transformations
+std::string pyne::to_str(int t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+std::string pyne::to_str(unsigned int t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+std::string pyne::to_str(double t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+std::string pyne::to_str(bool t) {
+  std::stringstream ss;
+  ss << t;
+  return ss.str();
+}
+
+
+int pyne::to_int(std::string s) {
+  return atoi( s.c_str() );
+}
+
+double pyne::to_dbl(std::string s) {
+  return strtod( s.c_str(), NULL );
+}
+
+double pyne::endftod_cpp(char * s) {
+  // Converts string from ENDF only handles "E-less" format but is 5x faster
+  int pos, mant, exp;
+  double v, dbl_exp;
+
+  mant = exp = 0;
+  if (s[2] == '.') {
+    // Convert an ENDF float
+    if (s[9] == '+' || s[9] == '-') {
+      // All these factors of ten are from place values.
+      mant = s[8] + 10 * s[7] + 100 * s[6] + 1000 * s[5] + 10000 * s[4] + \
+             100000 * s[3] + 1000000 * s[1] - 1111111 * '0';
+      exp = s[10] - '0';
+      // Make the right power of 10.
+      dbl_exp = exp & 01? 10.: 1;
+      dbl_exp *= (exp >>= 1) & 01? 100.: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e4: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e8: 1;
+      // Adjust for powers of ten from treating mantissa as an integer.
+      dbl_exp = (s[9] == '-'? 1/dbl_exp: dbl_exp) * 1.0e-6;
+      // Get mantissa sign, apply exponent.
+      v = mant * (s[0] == '-'? -1: 1) * dbl_exp;
+    } else {
+      mant = s[7] + 10 * s[6] + 100 * s[5] + 1000 * s[4] + 10000 * s[3] + \
+             100000 * s[1] - 111111 * '0';
+      exp = s[10] + 10 * s[9] - 11 * '0';
+      dbl_exp = exp & 01? 10.: 1;
+      dbl_exp *= (exp >>= 1) & 01? 100.: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e4: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e8: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e16: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e32: 1;
+      dbl_exp *= (exp >>= 1) & 01? 1.0e64: 1;
+      dbl_exp = (s[8] == '-'? 1/dbl_exp: dbl_exp) * 1.0e-5;
+      v = mant * (s[0] == '-'? -1: 1) * dbl_exp;
+    }
+  }
+
+  // Convert an ENDF int to float; we start from the last char in the field and
+  // move forward until we hit a non-digit.
+  else {
+    v = 0;
+    mant = 1; // Here we use mant for the place value about to be read in.
+    pos = 10;
+    while (s[pos] != '-' && s[pos] != '+' && s[pos] != ' ' && pos > 0) {
+      v += mant * (s[pos] - '0');
+      mant *= 10;
+      pos--;
+    }
+    v *= (s[pos] == '-'? -1: 1);
+  }
+  return v;
+}
+
+double (*pyne::endftod)(char * s) = &pyne::endftod_cpp;
+
+void pyne::use_fast_endftod() {
+  pyne::endftod = &pyne::endftod_cpp;
+}
+
+std::string pyne::to_upper(std::string s) {
+  // change each element of the string to upper case.
+  for(unsigned int i = 0; i < s.length(); i++)
+    s[i] = toupper(s[i]);
+  return s;
+}
+
+std::string pyne::to_lower(std::string s) {
+  // change each element of the string to lower case
+  for(unsigned int i = 0; i < s.length(); i++)
+    s[i] = tolower(s[i]);
+  return s;
+}
+
+std::string pyne::comment_line_wrapping(std::string line,
+                                               std::string comment_prefix,
+                                               int line_length) {
+  std::ostringstream oss;
+
+  line_length -= comment_prefix.length();
+    
+  // Include as is if short enough
+  while (line.length() > line_length) {
+    oss << comment_prefix << line.substr(0, line_length) << std::endl;
+    line.erase(0, line_length);
+  }
+
+  if (line.length() > 0) {
+    oss << comment_prefix << line << std::endl;
+  }
+
+  return oss.str();
+}
+
+std::string pyne::capitalize(std::string s) {
+  unsigned int slen = s.length();
+  if (slen == 0)
+    return s;
+  // uppercase the first character
+  s[0] = toupper(s[0]);
+  // change each subsequent element of the string to lower case
+  for(unsigned int i = 1; i < slen; i++)
+    s[i] = tolower(s[i]);
+  return s;
+}
+
+
+std::string pyne::get_flag(char line[], int max_l) {
+  char tempflag [10];
+  for (int i = 0; i < max_l; i++)
+  {
+    if (line[i] == '\t' || line[i] == '\n' || line[i] == ' ' || line[i] == '\0')
+    {
+      tempflag[i] = '\0';
+      break;
+    }
+    else
+      tempflag[i] = line[i];
+  }
+  return std::string (tempflag);
+}
+
+
+
+std::string pyne::remove_substring(std::string s, std::string substr) {
+  // Removes a substring from the string s
+  int n_found = s.find(substr);
+  while ( 0 <= n_found ) {
+    s.erase( n_found , substr.length() );
+    n_found = s.find(substr);
+  }
+  return s;
+}
+
+
+std::string pyne::remove_characters(std::string s, std::string chars) {
+  // Removes all characters in the string chars from the string s
+  for (int i = 0; i < chars.length(); i++ ) {
+    s = remove_substring(s, chars.substr(i, 1) );
+  }
+  return s;
+}
+
+
+std::string pyne::replace_all_substrings(std::string s, std::string substr, std::string repstr) {
+  // Replaces all instance of substr in s with the string repstr
+  int n_found = s.find(substr);
+  while ( 0 <= n_found ) {
+    s.replace( n_found , substr.length(), repstr );
+    n_found = s.find(substr);
+  }
+  return s;
+}
+
+
+
+std::string pyne::last_char(std::string s) {
+    // Returns the last character in a string.
+    return s.substr(s.length()-1, 1);
+}
+
+
+std::string pyne::slice_from_end(std::string s, int n, int l) {
+  // Returns the slice of a string using negative indices.
+  return s.substr(s.length()+n, l);
+}
+
+
+bool pyne::ternary_ge(int a, int b, int c) {
+  // Returns true id a <= b <= c and flase otherwise.
+  return (a <= b && b <= c);
+}
+
+
+bool pyne::contains_substring(std::string s, std::string substr) {
+  // Returns a boolean based on if the sub is in s.
+  int n = s.find(substr);
+  return ( 0 <= n && n < s.length() );
+}
+
+
+std::string pyne::natural_naming(std::string name) {
+  // Calculates a version on the string name that is a valid
+  // variable name, ie it uses only word characters.
+  std::string nat_name (name);
+
+  // Replace Whitespace characters with underscores
+  nat_name = pyne::replace_all_substrings(nat_name, " ",  "_");
+  nat_name = pyne::replace_all_substrings(nat_name, "\t", "_");
+  nat_name = pyne::replace_all_substrings(nat_name, "\n", "_");
+
+  // Remove non-word characters
+  int n = 0;
+  while ( n < nat_name.length() ) {
+    if ( pyne::words.find(nat_name[n]) == std::string::npos )
+      nat_name.erase(n, 1);
+    else
+      n++;
+  }
+
+  // Make sure that the name in non-empty before continuing
+  if (nat_name.length() == 0)
+    return nat_name;
+
+  // Make sure that the name doesn't begin with a number.
+  if ( pyne::digits.find(nat_name[0]) != std::string::npos)
+    nat_name.insert(0, "_");
+
+  return nat_name;
+}
+
+
+std::vector<std::string> pyne::split_string(std::string particles_list, std::string delimiter) {
+  std::vector<std::string> output_vector;
+  size_t prev_pos = 0; //item start position
+  size_t pos = 0; //item end position
+ 
+  while( (pos = particles_list.find(delimiter, prev_pos)) != std::string::npos){
+    output_vector.push_back(particles_list.substr(prev_pos, pos));
+    prev_pos = pos + delimiter.length();
+  }
+  // catch list with a single particle
+  if (pos == std::string::npos && prev_pos == 0 && particles_list.length() >0)
+    output_vector.push_back(particles_list);
+
+  return output_vector;
+}
+
+
+//
+// Math Helpers
+//
+
+double pyne::slope(double x2, double y2, double x1, double y1) {
+  // Finds the slope of a line.
+  return (y2 - y1) / (x2 - x1);
+}
+
+
+double pyne::solve_line(double x, double x2, double y2, double x1, double y1) {
+  return (slope(x2,y2,x1,y1) * (x - x2)) + y2;
+}
+
+
+double pyne::tanh(double x) {
+  return std::tanh(x);
+}
+
+double pyne::coth(double x) {
+  return 1.0 / std::tanh(x);
+}
+
+
+
+// File Helpers
+
+bool pyne::file_exists(std::string strfilename) {
+  // Thank you intarwebz for this function!
+  // Sepcifically: http://www.techbytes.ca/techbyte103.html
+  struct stat stFileInfo;
+  bool blnReturn;
+  int intStat;
+
+  // Attempt to get the file attributes
+  intStat = stat(strfilename.c_str(), &stFileInfo);
+
+  if(intStat == 0) {
+    // We were able to get the file attributes
+    // so the file obviously exists.
+    blnReturn = true;
+  }
+  else {
+    // We were not able to get the file attributes.
+    // This may mean that we don't have permission to
+    // access the folder which contains this file. If you
+    // need to do that level of checking, lookup the
+    // return values of stat which will give you
+    // more details on why stat failed.
+    blnReturn = false;
+  }
+
+  return(blnReturn);
+}
+
+// convert convert a filename into path+filename (for pyne)
+std::string pyne::get_full_filepath(char* filename) {
+  std::string file(filename);
+  return pyne::get_full_filepath(file);
+}
+
+// convert convert a filename into path+filename (for pyne)
+std::string pyne::get_full_filepath(std::string filename) {
+  // remove all extra whitespace
+  filename = pyne::remove_characters(" " , filename);
+  // use stdlib call
+#ifndef _WIN32
+  const std::string full_filepath = realpath(filename.c_str(), NULL);
+#else
+  const std::string  full_filepath = std::filesystem::canonical(filename.c_str()).string();
+#endif
+  return full_filepath;
+}
+
+// Message Helpers
+
+bool pyne::USE_WARNINGS = true;
+
+bool pyne::toggle_warnings(){
+  USE_WARNINGS = !USE_WARNINGS;
+  return USE_WARNINGS;
+}
+
+void pyne::warning(std::string s){
+  // Prints a warning message
+  if (USE_WARNINGS){
+    std::cout << "\033[1;33m WARNING: \033[0m" << s << "\n";
+  }
+}
+
+
+
+

--- a/src/cpp/utils.h
+++ b/src/cpp/utils.h
@@ -1,0 +1,237 @@
+/// \brief This is the base PyNE library.
+///
+/// It contains a lot of utility functions and constants that are globaly useful
+/// through out the rest of the PyNE infrastructure.
+///
+
+// Header for general library file.
+
+#ifndef PYNE_KMMHYNANYFF5BFMEYIP7TUNLHA
+#define PYNE_KMMHYNANYFF5BFMEYIP7TUNLHA
+
+//standard libraries
+#include <string>
+#include <string.h>
+#include <sstream>
+#include <cctype>
+#include <stdlib.h>
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <exception>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+
+#if (__GNUC__ >= 4)
+  #include <cmath>
+  #define isnan(x) std::isnan(x)
+#else
+  #include <math.h>
+  #define isnan(x) __isnand((double)x)
+#endif
+
+#ifdef _WIN32
+#define isnan(x) ((x) != (x))
+#endif
+
+#ifndef JSON_IS_AMALGAMATION
+  #define JSON_IS_AMALGAMATION
+#endif
+
+/// The 'pyne' namespace all PyNE functionality is included in.
+namespace pyne {
+
+  void pyne_start (); ///< Initializes PyNE based on environment.
+
+  // String Transformations
+  /// string of digit characters
+  static std::string digits = "0123456789";
+  /// uppercase alphabetical characters
+  static std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  /// string of all valid word characters for variable names in programing languages.
+  static std::string words = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_";
+
+  /// \name String Conversion Functions
+  /// \{
+  /// Converts the variables of various types to their C++ string representation.
+  std::string to_str(int t);
+  std::string to_str(unsigned int t);
+  std::string to_str(double t);
+  std::string to_str(bool t);
+  /// \}
+
+  int to_int(std::string s);  ///< Converts a string of digits to an int using atoi().
+
+  double to_dbl(std::string s);  ///< Converts a valid string to a float using atof().
+
+  /// Converts a string from ENDF format to a float. Only handles E-less format
+  /// but is roughly 5 times faster than endftod.
+  double endftod_cpp(char * s);
+  extern  double (*endftod)(char * s); ///< endftod function pointer. defaults to fortran
+
+  void use_fast_endftod();/// switches endftod to fast cpp version
+
+  /// Returns an all upper case copy of the string.
+  std::string to_upper(std::string s);
+
+  /// Returns an all lower case copy of the string.
+  std::string to_lower(std::string s);
+
+  /// Returns a capitalized copy of the string.
+  std::string capitalize(std::string s);
+
+  /// Forms and returns the wrapped lines with a lenght up to line_lenght.
+  std::string comment_line_wrapping(std::string line, std::string comment_prefix = "",
+                                           int line_length = 79);
+
+  /// Finds and returns the first white-space delimited token of a line.
+  /// \param line a character array to take the first token from.
+  /// \param max_l an upper bound to the length of the token.  Must be 11 or less.
+  /// \returns a the flag as a string
+  std::string get_flag(char line[], int max_l);
+
+  /// Creates a copy of \a s with all instances of \a substr taken out.
+  std::string remove_substring(std::string s, std::string substr);
+
+  /// Removes all characters in the string \a chars from \a s.
+  std::string remove_characters(std::string s, std::string chars);
+
+  /// Replaces all instance of \a substr in \a s with \a repstr.
+  std::string replace_all_substrings(std::string s, std::string substr,
+                                                    std::string repstr);
+
+  /// Returns the last character in a string.
+  std::string last_char(std::string s);
+
+  /// Returns the slice of a string \a s using the negative index \a n and the
+  /// length of the slice \a l.
+  std::string slice_from_end(std::string s, int n=-1, int l=1);
+
+  /// Returns true if \a a <= \a b <= \a c and flase otherwise.
+  bool ternary_ge(int a, int b, int c);
+
+  /// Returns true if \a substr is in \a s.
+  bool contains_substring(std::string s, std::string substr);
+
+  /// Calculates a version of the string \a name that is also a valid variable name.
+  /// That is to say that the return value uses only word characters.
+  std::string natural_naming(std::string name);
+
+  // split a string into a vector of string using a delimiter
+  std::vector<std::string> split_string(std::string lists, std::string delimiter = " ");
+
+  // join the vector element into a string, each values will be delimited ny the delimiter
+  template<typename T>
+  std::string join_to_string(std::vector<T> vect, std::string delimiter = " "){
+    std::stringstream out;
+    out << std::setiosflags(std::ios::fixed) << std::setprecision(6);
+
+    // ensure there is at least 1 element in the vector
+    if (vect.size() == 0)
+      return out.str();
+    // no delimiter needed before the first element
+    out << vect[0];
+    for( int i = 1; i < vect.size(); i++)
+      out << delimiter << vect[i];
+    return out.str();
+  };
+  template std::string join_to_string(std::vector<int> vect,
+                                      std::string delimiter);
+  template std::string join_to_string(std::vector<double> vect,
+                                      std::string delimiter);
+  template std::string join_to_string(std::vector<std::string> vect, std::string delimiter);
+
+  /// Finds the slope of a line from the points (\a x1, \a y1) and (\a x2, \a y2).
+  double slope (double x2, double y2, double x1, double y1);
+
+  /// Solves the equation for the line y = mx + b, given \a x and the points that
+  /// form the line: (\a x1, \a y1) and (\a x2, \a y2).
+  double solve_line (double x, double x2, double y2, double x1, double y1);
+
+  double tanh(double x);  ///< The hyperbolic tangent function.
+  double coth(double x);  ///< The hyperbolic cotangent function.
+
+
+  // File Helpers
+  /// Returns true if the file can be found.
+  bool file_exists(std::string strfilename);
+
+  // turns the filename string into the full file path
+  std::string get_full_filepath(char* filename);
+  // turns the filename string into the full file path
+  std::string get_full_filepath(std::string filename);
+
+  // Message Helpers
+  extern bool USE_WARNINGS;
+  /// Toggles warnings on and off
+  bool toggle_warnings();
+
+  /// Prints a warning message.
+  void warning(std::string s);
+
+  /// Custom exception to be thrown in the event that a required file is not able to
+  /// be found.
+  class FileNotFound : public std::exception
+  {
+  public:
+
+    /// default constructor
+    FileNotFound () {};
+
+    /// default destructor
+    ~FileNotFound () throw () {};
+
+    /// constructor with the filename \a fname.
+    FileNotFound(std::string fname)
+    {
+      FNF_message = "File not found";
+      if (!fname.empty())
+        FNF_message += ": " + fname;
+    };
+
+    /// Creates a helpful error message.
+    virtual const char* what() const throw()
+    {
+      return FNF_message.c_str();
+    };
+
+  private:
+    std::string FNF_message; /// Message for exception
+  };
+
+  /// Exception representing value errors of all kinds
+  class ValueError : public std::exception
+  {
+  public:
+
+    /// default constructor
+    ValueError () {};
+
+    /// default destructor
+    ~ValueError () throw () {};
+
+    /// constructor with the filename \a fname.
+    ValueError(std::string msg)
+    {
+      message = "ValueError: " + msg;
+    };
+
+    /// Creates a helpful error message.
+    virtual const char* what() const throw()
+    {
+      const char* msgstr_rtn = message.c_str();
+      return msgstr_rtn;
+    };
+
+  protected:
+    std::string message; ///< extra message for the user.
+  };
+
+
+// End PyNE namespace
+}
+
+#endif  // PYNE_KMMHYNANYFF5BFMEYIP7TUNLHA


### PR DESCRIPTION
This provides all of the PyNE utils **except** the following from the original PyNE:

1. a small piece of FORTRAN code to facilitate robust conversion of ENDF formatted data to floats/doubles.
2. some global references to data an versions
3. special handling of nuc data in `pyne_start`